### PR TITLE
Update openstad-frontend apostrophe to 2.113.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2387,7 +2387,7 @@
     "@openstad/cms": {
       "version": "file:packages/cms",
       "requires": {
-        "apostrophe": "2.107.2",
+        "apostrophe": "2.113.0",
         "apostrophe-area-structure": "^1.0.3",
         "apostrophe-blog": "^2.1.2",
         "apostrophe-palette": "^2.0.23",
@@ -7112,28 +7112,28 @@
       "integrity": "sha1-CH4fELBGky/IWU3Z5tN4r8nR5aw="
     },
     "heic-convert": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/heic-convert/-/heic-convert-1.2.3.tgz",
-      "integrity": "sha512-wzt0jCoD0d5Ek/cwU65pqRcP25ZKiBlcZ3LCa0USpbtrrfsnsVFLXzrWcHZLnINoVYXRvoIiGjVw6aKvSKaWCQ==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/heic-convert/-/heic-convert-1.2.4.tgz",
+      "integrity": "sha512-klJHyv+BqbgKiCQvCqI9IKIvweCcohDuDl0Jphearj8+16+v8eff2piVevHqq4dW9TK0r1onTR6PKHP1I4hdbA==",
       "requires": {
-        "heic-decode": "^1.1.0",
+        "heic-decode": "^1.1.2",
         "jpeg-js": "^0.4.1",
         "pngjs": "^3.4.0"
       },
       "dependencies": {
         "jpeg-js": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.2.tgz",
-          "integrity": "sha512-+az2gi/hvex7eLTMTlbRLOhH6P6WFdk2ITI8HJsaH2VqYO0I594zXSYEP+tf4FW+8Cy68ScDXoAsQdyQanv3sw=="
+          "version": "0.4.3",
+          "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.3.tgz",
+          "integrity": "sha512-ru1HWKek8octvUHFHvE5ZzQ1yAsJmIvRdGWvSoKV52XKyuyYA437QWDttXT8eZXDSbuMpHlLzPDZUPd6idIz+Q=="
         }
       }
     },
     "heic-decode": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/heic-decode/-/heic-decode-1.1.1.tgz",
-      "integrity": "sha512-0KKYaXk2QSZrQIp4UKaNt/tyK8UGZkdfTzZRzny+cyYbNPJXRicaLCphMOuaBxHpHvCBTqnl0rM0qQ+rN98gJg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/heic-decode/-/heic-decode-1.1.2.tgz",
+      "integrity": "sha512-UF8teegxvzQPdSTcx5frIUhitNDliz/9Pui0JFdIqVRE00spVE33DcCYtZqaLNyd4y5RP/QQWZFIc1YWVKKm2A==",
       "requires": {
-        "libheif-js": "^1.6.1"
+        "libheif-js": "^1.10.0"
       }
     },
     "heic-to-jpeg-middleware": {
@@ -8164,9 +8164,9 @@
       }
     },
     "libheif-js": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/libheif-js/-/libheif-js-1.9.1.tgz",
-      "integrity": "sha512-tWaVeeKs0ikAkh1Rlad9kWslRn8c0c52yIJvrsEPPsvla+BTDADFOhd+AaczGtMOVqeErg6HnLU+b33XkbdfCw=="
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/libheif-js/-/libheif-js-1.10.0.tgz",
+      "integrity": "sha512-o6lxGpy5RmO8aUMnDuHulkLd0g0QFWPWbZ5fjq2SM+E/xpeCTw5l+p//r8dmgKQiPzcXyitLr27gdGOLBIKBfg=="
     },
     "lines-and-columns": {
       "version": "1.1.6",
@@ -15569,9 +15569,9 @@
       }
     },
     "uploadfs": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/uploadfs/-/uploadfs-1.17.1.tgz",
-      "integrity": "sha512-50bxm4CA40SWknUO17jYVr3TkNNGObOVHurW8Fc/qZ3X14S2R6wW9vZVtE1418f5Zjm4ea4iFb6Ixw7pGjSq6g==",
+      "version": "1.17.2",
+      "resolved": "https://registry.npmjs.org/uploadfs/-/uploadfs-1.17.2.tgz",
+      "integrity": "sha512-Fk+je/PAf+DV+HUT0Ykjg8c63Adbh+SSzq7z7J+0XN/h2Ofj5niyxt3FfTG33HiqORB+6b/Hh2xGKsT+Likr3Q==",
       "requires": {
         "@google-cloud/storage": "^5.3.0",
         "async": "^1.0.0",


### PR DESCRIPTION
This fixes a bug with apostrophe's oembed which caused YouTube videos to no longer work.

See https://github.com/apostrophecms/apostrophe/discussions/2632 for more information.