### PR TITLE
Add fixed endpoint for vimeo.com oembeds

### DIFF
--- a/packages/cms/config/siteConfig.js
+++ b/packages/cms/config/siteConfig.js
@@ -138,7 +138,11 @@ module.exports = {
           siteUrl: siteUrl,
         },
         'openstad-custom-pages': {},
-        'openstad-oembed': {},
+        'openstad-oembed': {
+          endpoints: [
+            { domain: 'vimeo.com', endpoint: 'https://vimeo.com/api/oembed.json' }
+          ]
+        },
 
 
         // Apostrophe module configuration


### PR DESCRIPTION
This prevents oembetter from scraping vimeo.com, which can be blocked or might return incorrect data.