### PR TITLE
Allow an image to be linked

### DIFF
--- a/packages/cms/lib/modules/image-widgets/index.js
+++ b/packages/cms/lib/modules/image-widgets/index.js
@@ -28,6 +28,48 @@ module.exports = {
       label: 'Textual alternative',
       type: 'string'
     },
+    {
+      name: 'useLink',
+      label: 'Add a link to the image?',
+      type: 'boolean',
+      choices: [
+        {
+          label: 'Ja',
+          value: true,
+          showFields: [
+            'url',
+            'targetBlank',
+          ]
+        },
+        {
+          label: 'Nee',
+          value: false,
+        }
+      ],
+      def: false
+    },
+    {
+      name: 'url',
+      type: 'url',
+      label: 'URL',
+      required: true
+    },
+    {
+      name: 'targetBlank',
+      type: 'boolean',
+      label: 'Open in new window',
+      choices: [
+        {
+          label: 'Ja',
+          value: true,
+        },
+        {
+          label: 'Nee',
+          value: false,
+        }
+      ],
+      def: false
+    },
     styleSchema.definition('imageStyles', 'Styles for the image'),
 
   ],
@@ -36,7 +78,7 @@ module.exports = {
       {
         name: 'generalGroup',
         label: 'General',
-        fields: ['uploadedImage']
+        fields: ['uploadedImage', 'uploadedImageTitle', 'uploadedImageAlt', 'useLink', 'url', 'targetBlank']
       },
       {
         name: 'stylingGroup',

--- a/packages/cms/lib/modules/image-widgets/views/widget.html
+++ b/packages/cms/lib/modules/image-widgets/views/widget.html
@@ -2,9 +2,22 @@
   {{data.widget.formattedImageStyles}}
 </style>
 
-<img
-  id="{{data.widget.imageId}}"
-  src="{{apos.attachments.url(data.widget.uploadedImage)}}"
-  title="{{data.widget.uploadedImageTitle}}"
-  alt="{{data.widget.uploadedImageAlt}}"
-/>
+{% if data.widget.useLink %}
+<a
+  id="{{data.widget.imageId}}-link"
+  href="{{ data.widget.url | safeRelativeUrl }}"
+  {% if data.widget.targetBlank %} target="_blank" {% endif %}
+  style=""
+>
+{% endif %}
+
+    <img
+      id="{{data.widget.imageId}}"
+      src="{{apos.attachments.url(data.widget.uploadedImage)}}"
+      title="{{data.widget.uploadedImageTitle}}"
+      alt="{{data.widget.uploadedImageAlt}}"
+    />
+
+{% if data.widget.useLink %}
+</a>
+{% endif %}


### PR DESCRIPTION
Adds the option to add an `<a>` tag around an image, where the URL is user-definable and a `target="_blank"` can be applied.

The `<a>` tag gets the ID of the image element with `-link` appended.