### PR TITLE
Treat formatted search text as unsafe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## URELEASED 2
+* Make embedded auth forms label en button text configurable in widget
+* Fix counter button urls in subdir sites
+* Fix HTML injection in search form in the resource overview widget
+
 ## v0.20.2
 * Fix resource overview widget error: TypeError: Cannot read property 'automaticallyUpdateStatus' of undefined
 

--- a/packages/cms/lib/modules/resource-overview-widgets/views/widget.html
+++ b/packages/cms/lib/modules/resource-overview-widgets/views/widget.html
@@ -22,7 +22,7 @@
 
 			{% if data.widget.formattedSearchText %}
 			<div class="resource-overview-counter-text ">
-				{{data.widget.formattedSearchText | sanitize | safe}}
+				{{ data.widget.formattedSearchText }}
 			</div>
 			{% endif %}
 


### PR DESCRIPTION
This fixes the possible HTML injection through the search form in the resource-overview widget.

It was possible to inject HTML through the search query, e.g.: ?search=Een%20rode%20kat%20die%20zich%20altijd%20in%20de%20nesten%20werkt%22%3E%3Ca%20href=https://dn.ht/picklecat%3E%3Cimg%20src=https://dikkiedikboeken.nl/wp-content/uploads/2019/07/DD52.jpg%3E%3C/a%3E%3C%2Fa%3E